### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,29 @@ http://www.pointclouds.org/downloads/windows.html
 
 #### Install via Homebrew
 1. install [homebrew](https://brew.sh/)
-2. update homebrew `$> brew update`
-3. add  homebrew science [tap](https://docs.brew.sh/Taps) `$> brew tap brewsci/science`
-4. view pcl install options `$> brew options pcl`
-5. install PCL `$> brew install pcl`
+2. update homebrew 
+	```bash
+	$> brew update
+	```
+3. add  homebrew science [tap](https://docs.brew.sh/Taps) 
+		```bash
+		$> brew tap brewsci/science
+	```
+4. view pcl install options
+	```bash
+	$> brew options pcl
+	```
+5. install PCL 
+	```bash
+	$> brew install pcl
+	```
 
 #### Prebuilt Binaries via Universal Installer
-http://www.pointclouds.org/downloads/macosx.html
+http://www.pointclouds.org/downloads/macosx.html  
 NOTE: very old version 
 
 #### Build from Source
+
 [PCL Source Github](https://github.com/PointCloudLibrary/pcl)
+
 [PCL Mac Compilation Docs](http://www.pointclouds.org/documentation/tutorials/compiling_pcl_macosx.php)

--- a/README.md
+++ b/README.md
@@ -25,8 +25,17 @@ http://www.pointclouds.org/downloads/windows.html
 
 ### MAC
 
+#### Install via Homebrew
+1. install [homebrew](https://brew.sh/)
+2. update homebrew `$> brew update`
+3. add  homebrew science [tap](https://docs.brew.sh/Taps) `$> brew tap brewsci/science`
+4. view pcl install options `$> brew options pcl`
+5. install PCL `$> brew install pcl`
+
+#### Prebuilt Binaries via Universal Installer
 http://www.pointclouds.org/downloads/macosx.html
-http://www.pointclouds.org/documentation/tutorials/installing_homebrew.php
+NOTE: very old version 
 
-
-
+#### Build from Source
+[PCL Source Github](https://github.com/PointCloudLibrary/pcl)
+[PCL Mac Compilation Docs](http://www.pointclouds.org/documentation/tutorials/compiling_pcl_macosx.php)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ http://www.pointclouds.org/downloads/windows.html
 	$> brew update
 	```
 3. add  homebrew science [tap](https://docs.brew.sh/Taps) 
-		```bash
-		$> brew tap brewsci/science
+	```bash
+	$> brew tap brewsci/science
 	```
 4. view pcl install options
 	```bash


### PR DESCRIPTION
The instructions at `http://www.pointclouds.org/documentation/tutorials/installing_homebrew.php` are out of date and no longer working since`brew tap homebrew/science` was deprecated.