### PR TITLE
docs: update ubuntu pcl install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,16 @@ In this course we will be talking about sensor fusion, whch is the process of ta
 
 ### Ubuntu 
 
-https://askubuntu.com/questions/916260/how-to-install-point-cloud-library-v1-8-pcl-1-8-0-on-ubuntu-16-04-2-lts-for
+```bash
+$> sudo apt install libpcl-dev
+$> cd ~
+$> git clone https://github.com/udacity/SFND_Lidar_Obstacle_Detection.git
+$> cd SFND_Lidar_Obstacle_Detection
+$> mkdir build && cd build
+$> cmake ..
+$> make
+$> ./environment
+```
 
 ### Windows 
 


### PR DESCRIPTION
The installation instructions at the given link are out of date
 https://askubuntu.com/questions/916260/how-to-install-point-cloud-library-v1-8-pcl-1-8-0-on-ubuntu-16-04-2-lts-for 
see https://launchpad.net/~webupd8team/+archive/ubuntu/java

The official PCL documentation are out of date too http://pointclouds.org/downloads/linux.html
see https://launchpad.net/~v-launchpad-jochen-sprickerhof-de/+archive/ubuntu/pcl

Currently, PCL is either included with Ubuntu or can be installed via apt-get (as mentioned by deprecation message at above PPA link)

updated instructions were tested on 2 different ubuntu machines.