### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ $> ./environment
 
 http://www.pointclouds.org/downloads/windows.html
 
+**NOTE:** The original website (http://pointclouds.org) is down currently. In the meantime, PCL's documentation can be accessed at the following locations:
+- API reference: http://pointclouds.org;
+- Tutorials: https://pcl-tutorials.readthedocs.io/;
+- Advanced Tutorials: https://pcl-advanced.readthedocs.io/.
+
+If you really need access to the old website, please use [the copy made by the internet archive](https://web.archive.org/web/20191017164724/http://www.pointclouds.org/). Please be aware that the website was hacked before and could still be hosting some malicious code.
+
 ### MAC
 
 #### Install via Homebrew


### PR DESCRIPTION
The original website of PCL is unavailable  and the link stated is no longer valid. 
In the meanwhile the maintainers fix the website, I have added the documentation available at the PCL Github profile to the README markdown.